### PR TITLE
Some simple ideas (untested) for html.reb and rem.reb

### DIFF
--- a/usr/lib/r3/html.reb
+++ b/usr/lib/r3/html.reb
@@ -12,41 +12,34 @@ REBOL [
   Version: 0.1.1
 ]
 
-mold-style: func [
+mold-style: function [
   x [block! string!]
-  ret:
-  ][
-  if string? x [return x]
-  ret: make string! 32
-  foreach [k v] x [
-    if not empty? ret [append ret "; "]
-    append ret k
-    append ret ": "
-    append ret v
+ ][
+  if string? x [x] else [
+    delimit map-each [k v] x [
+      unspaced [k ":" space v]
+    ] "; "
   ]
-  ret
 ]
 
-quote-html: func [
-    x [string!] q:
-  ] [
+quote-html: function [
+    x [string!]
+ ][
   q: charset "<&>"
-  parse x [any [to q
-		[ #"&" insert "amp;"
-		| remove #"<" insert "&lt;"
-		| remove #">" insert "&gt;"
-		]
-  ] ]
+  parse x [any [to q [
+    "&" insert "amp;"
+    | remove "<" insert "&lt;"
+    | remove ">" insert "&gt;"
+  ]]]
   x
 ]
 
-mold-html: func [
+mold-html: function [
   x
   /into ret
-  empty:
-  ][
-  unless into [ret: make string! 256]
+ ][
   unless x [return x]
+  ret: default [make string! 256]
   unless block? x [
     return append ret quote-html form x
   ]
@@ -60,23 +53,23 @@ mold-html: func [
         ]
         k: to-string k
         if empty: (#"/" = last k) [take/last k]
-        append ret #"<"
-        append ret k
+        adjoin ret ["<" k]
         if block? v [while [word? v/1] [
-          append ret space
-          append ret v/1
-          append ret #"="
-          append ret quote-string either
-            'style = v/1
-            [ mold-style v/2 ]
-            [ to-string v/2 ]
+          adjoin ret [
+            space v/1 "="
+            quote-string either 'style = v/1 [
+              mold-style v/2
+             ][
+              to-string v/2
+            ]
+          ]
           v: skip v 2
         ]]
         if empty [append ret " /"]
-        append ret #">"
+        append ret ">"
         unless empty [
           mold-html/into v ret
-          append ret ajoin ["</" k #">"]
+          adjoin ret ["</" k ">"]
         ]
      ]
     ]


### PR DESCRIPTION
I would suggest that if you want to bend the bracket conventions that
you *half-indent* instead of full indent the un-aligned brackets.
Take a look and see if you think this meets your needs while not
being quite as jarring.

* Prefer hyphenated names, like **for-skip** over **forskip**

* Try using MAYBE ... it's supposed to be a testing dialect, has a
  related routine ENSURE which will give an error if the tests aren't
  passed, but MAYBE just returns blank if the tests don't pass.  I'd
  like to get some feedback on it.

* Would like to get feedback on DEFAULT too

* Unless you *have* to use a character, use a string because I think
  it looks cleaner.  In the future, I think **=** will be strict, and
  **is** will be relaxed, and I think **#"A" is "a"** will be true.

* BAR! is good for making clear things like **t: node take node**,
  that's what it's for... so you can see **t: node | take node**.

* UNSPACED is a nicer word for what AJOIN does, and remember there is
  also a SPACED if you need it, and DELIMIT.

* FUNCTION is supposed to save you from having to manually declare
  your locals.

* RETURN: by convention should probably be the *first* argument.  It's
  not necessary, but it's the convention I think makes the most sense.

* If you find yourself building a buffer, having to decide what size
  to make it, and appending to it, remember things like MAP-EACH and
  COLLECT are there.  I tried a little example that might work.

* ADJOIN is the temporary name for what will be JOIN, which is Ren-C's
  version of REPEND.  It appends a block of things, reducing them, and
  any voids will be dropped.  Will look even nicer when it is just
  JOIN!